### PR TITLE
Add AtlasYield to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[AtlasYield](https://atlasyield.club/)** - An independent rating and allocation layer for on-chain yield, scoring DeFi vaults 0-100 across 16 factors with a public read-only scores API.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adds AtlasYield (https://atlasyield.club) to the Analytics and Data Tools section. It scores DeFi yield vaults 0-100 across 16 risk and return factors and exposes the scores through a public read-only API.

Placed alongside the other risk/scoring data tools in that section (Pharos, Sharpe) rather than Security and Auditing, which lists audit firms and bug bounty platforms. Format matches the surrounding entries; link verified live.