### PR TITLE
Add Formo Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[Formo Analytics](https://formo.so/)** - Product and on-chain analytics for DeFi teams, including wallet profiles, funnels, retention, revenue, and SQL.
 
 ## Security and Auditing
 


### PR DESCRIPTION
## Description of the change

Adds one resource—[Formo Analytics](https://formo.so/)—to Analytics and Data Tools.

This revised submission follows the feedback on #45 by limiting the change to one independently reviewable resource. Formo provides product and on-chain analytics for DeFi teams, including wallet profiles, funnels, retention, revenue, and SQL.

## Checklist

- [x] The link is active and points to a legitimate resource.
- [x] The resource is relevant to DeFi analytics.
- [x] The description is short and objective.
- [x] This PR adds only one resource from Formo.
