### PR TITLE
Add Telem Incident Feed to Security and Auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - **[OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts/)** - A library of secure smart contracts used in DeFi.
 - **[Immunefi](https://immunefi.com/)** - A bug bounty platform for DeFi and crypto projects, incentivizing security researchers.
 - **[Quantstamp](https://quantstamp.com/)** - A smart contract auditing service for DeFi projects.
+- **[Telem Incident Feed](https://telem.news/security/incidents)** - A running record of DeFi exploits, hacks and rug pulls, with an original attributed brief per incident. Free, no login.
 
 ## Educational Resources
 


### PR DESCRIPTION
Adding the Telem Incident Feed to the Security and Auditing section — a continuously updated record of DeFi exploits, hacks and rug pulls (date, protocol, and an original attributed brief per incident): https://telem.news/security/incidents

I run Telem. It's free, no login, no paywall — a security resource that complements the audit firms already listed. Happy to move it to a different section or adjust the format.